### PR TITLE
Match any unexpected result as error

### DIFF
--- a/lib/fiet.ex
+++ b/lib/fiet.ex
@@ -104,6 +104,7 @@ defmodule Fiet do
     |> case do
       {:ok, false} -> :error
       {:ok, type} -> type
+      {:error, _reason} -> :error
     end
   end
 end

--- a/lib/fiet/rss2/engine.ex
+++ b/lib/fiet/rss2/engine.ex
@@ -51,6 +51,9 @@ defmodule Fiet.RSS2.Engine do
 
           {:ok, {:not_rss2, _root_tag} = reason} ->
             {:error, %ParsingError{reason: reason}}
+
+          {:error, reason} -> 
+            {:error, %ParsingError{reason: reason}}
         end
       end
 


### PR DESCRIPTION
When the library errors while parsing the feed, the resulting error is not correctly matched in the case. This is a fix for that.